### PR TITLE
fix: guard mobile menu access in shared.js

### DIFF
--- a/FE/scripts/shared.js
+++ b/FE/scripts/shared.js
@@ -2,7 +2,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const navbar = document.querySelector('.navbar');
   const mobileMenu = document.getElementById('mobileMenu');
 
-    if (mobileMenu.classList.contains('open')) {
+    if (mobileMenu && mobileMenu.classList.contains('open')) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- check `mobileMenu` exists before using it

## Testing
- `npm run build`
- `dotnet build DeliasWebsite.sln` *(fails: command not found)*
