### PR TITLE
Add cookie consent page and banner

### DIFF
--- a/DeliasWebsite.Core/Features/Cookies/CookieConsentController.cs
+++ b/DeliasWebsite.Core/Features/Cookies/CookieConsentController.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Web.Common.Controllers;
+using Microsoft.AspNetCore.Http;
+
+namespace DeliasWebsite.Core.Features.Cookies
+{
+    public class CookieConsentController : UmbracoPageController
+    {
+        public const string RoutePattern = "/cookie-consent";
+
+        public CookieConsentController(ILogger<CookieConsentController> logger, ICompositeViewEngine compositeViewEngine)
+            : base(logger, compositeViewEngine)
+        {
+        }
+
+        [HttpGet]
+        public IActionResult Index()
+        {
+            return View("~/Views/CookieConsent.cshtml");
+        }
+
+        [HttpPost]
+        [Route(RoutePattern + "/accept")]
+        [IgnoreAntiforgeryToken]
+        public IActionResult Accept()
+        {
+            Response.Cookies.Append("CookieConsent", "accepted", new CookieOptions
+            {
+                Expires = DateTimeOffset.UtcNow.AddYears(1)
+            });
+
+            return NoContent();
+        }
+
+        [HttpPost]
+        [Route(RoutePattern + "/decline")]
+        [IgnoreAntiforgeryToken]
+        public IActionResult Decline()
+        {
+            Response.Cookies.Append("CookieConsent", "declined", new CookieOptions
+            {
+                Expires = DateTimeOffset.UtcNow.AddYears(1)
+            });
+
+            return NoContent();
+        }
+    }
+}

--- a/DeliasWebsite/Program.cs
+++ b/DeliasWebsite/Program.cs
@@ -1,6 +1,7 @@
 using DeliasWebsite.Core.Features.Contact;
 using DeliasWebsite.Core.Features.Search;
 using DeliasWebsite.Core.Features.Seo;
+using DeliasWebsite.Core.Features.Cookies;
 using Microsoft.AspNetCore.HttpOverrides;
 using SixLabors.ImageSharp.Web.DependencyInjection;
 using Umbraco.Cms.Core.Services;
@@ -42,7 +43,14 @@ builder.Services.AddImageSharp(options =>
 
 builder.Services.Configure<UmbracoRequestOptions>(options =>
 {
-    string[] allowList = new[] { "/sitemap.xml", "/robots.txt" };
+    string[] allowList = new[]
+    {
+        "/sitemap.xml",
+        "/robots.txt",
+        CookieConsentController.RoutePattern,
+        CookieConsentController.RoutePattern + "/accept",
+        CookieConsentController.RoutePattern + "/decline"
+    };
     options.HandleAsServerSideRequest = httpRequest =>
     {
         foreach (string route in allowList)
@@ -93,6 +101,30 @@ app.UseUmbraco()
                           Controller = ControllerExtensions.GetControllerName<SitemapController>(),
                           Action = nameof(SitemapController.Index)
                       });
+        u.EndpointRouteBuilder.MapControllerRoute(
+            nameof(CookieConsentController),
+            CookieConsentController.RoutePattern,
+            new
+            {
+                Controller = ControllerExtensions.GetControllerName<CookieConsentController>(),
+                Action = nameof(CookieConsentController.Index)
+            });
+        u.EndpointRouteBuilder.MapControllerRoute(
+            "CookieConsentAccept",
+            CookieConsentController.RoutePattern + "/accept",
+            new
+            {
+                Controller = ControllerExtensions.GetControllerName<CookieConsentController>(),
+                Action = nameof(CookieConsentController.Accept)
+            });
+        u.EndpointRouteBuilder.MapControllerRoute(
+            "CookieConsentDecline",
+            CookieConsentController.RoutePattern + "/decline",
+            new
+            {
+                Controller = ControllerExtensions.GetControllerName<CookieConsentController>(),
+                Action = nameof(CookieConsentController.Decline)
+            });
         u.UseBackOfficeEndpoints();
         u.UseWebsiteEndpoints();
     });

--- a/DeliasWebsite/Views/CookieConsent.cshtml
+++ b/DeliasWebsite/Views/CookieConsent.cshtml
@@ -1,0 +1,81 @@
+@{
+    Layout = "Master.cshtml";
+}
+<section class="cookie-consent">
+    <div class="container">
+        <h1>Cookie Consent</h1>
+        <p>This page lists the cookies used on DeliasPortfolio.</p>
+        <table class="cookie-table">
+            <thead>
+                <tr>
+                    <th>Tracker name</th>
+                    <th>Provider</th>
+                    <th>Category</th>
+                    <th>Domain</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>ai_user</td>
+                    <td>www.deliasportfolio.com</td>
+                    <td>Statistics</td>
+                    <td>www.deliasportfolio.com</td>
+                </tr>
+                <tr>
+                    <td>_ga_#</td>
+                    <td>deliasportfolio.com</td>
+                    <td>Marketing</td>
+                    <td>www.deliasportfolio.com</td>
+                </tr>
+                <tr>
+                    <td>_ga</td>
+                    <td>deliasportfolio.com</td>
+                    <td>Marketing</td>
+                    <td>www.deliasportfolio.com</td>
+                </tr>
+                <tr>
+                    <td>ai_session</td>
+                    <td>www.deliasportfolio.com</td>
+                    <td>Necessary</td>
+                    <td>www.deliasportfolio.com</td>
+                </tr>
+                <tr>
+                    <td>CookieConsent</td>
+                    <td>www.deliasportfolio.com</td>
+                    <td>Necessary</td>
+                    <td>www.deliasportfolio.com</td>
+                </tr>
+                <tr>
+                    <td>ARRAffinity</td>
+                    <td>deliasportfolio-d7b0gka5e0e9a5cg.uksouth-01.azurewebsites.net</td>
+                    <td>Necessary</td>
+                    <td>www.deliasportfolio.com</td>
+                </tr>
+                <tr>
+                    <td>ARRAffinitySameSite</td>
+                    <td>deliasportfolio-d7b0gka5e0e9a5cg.uksouth-01.azurewebsites.net</td>
+                    <td>Necessary</td>
+                    <td>www.deliasportfolio.com</td>
+                </tr>
+                <tr>
+                    <td>theme</td>
+                    <td>www.deliasportfolio.com</td>
+                    <td>Necessary</td>
+                    <td>www.deliasportfolio.com</td>
+                </tr>
+                <tr>
+                    <td>AI_sentBuffer</td>
+                    <td>js.monitor.azure.com</td>
+                    <td>Necessary</td>
+                    <td>www.deliasportfolio.com</td>
+                </tr>
+                <tr>
+                    <td>AI_buffer</td>
+                    <td>js.monitor.azure.com</td>
+                    <td>Necessary</td>
+                    <td>www.deliasportfolio.com</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</section>

--- a/DeliasWebsite/Views/Master.cshtml
+++ b/DeliasWebsite/Views/Master.cshtml
@@ -75,6 +75,7 @@
             @await Html.PartialAsync("Partials/_Header")
             @RenderBody()
             @await Html.PartialAsync("Partials/_Footer")
+            @await Html.PartialAsync("Partials/_CookieConsentBanner")
     </div>
 </body>
 </html>

--- a/DeliasWebsite/Views/Partials/_CookieConsentBanner.cshtml
+++ b/DeliasWebsite/Views/Partials/_CookieConsentBanner.cshtml
@@ -1,0 +1,35 @@
+<div id="cookieConsentBanner" class="cookie-banner hidden">
+    <p>This site uses cookies to enhance your experience. <a href="/cookie-consent">Learn more</a>.</p>
+    <div class="cookie-actions">
+        <button id="acceptCookies" class="btn-primary">Accept</button>
+        <button id="declineCookies" class="btn-secondary">Decline</button>
+    </div>
+</div>
+<script>
+(function () {
+    function hasConsent() {
+        return document.cookie.split('; ').some(function (item) {
+            return item.startsWith('CookieConsent=');
+        });
+    }
+
+    var banner = document.getElementById('cookieConsentBanner');
+    if (!hasConsent()) {
+        banner.classList.remove('hidden');
+    }
+
+    function sendChoice(path) {
+        fetch(path, { method: 'POST' }).then(function () {
+            banner.classList.add('hidden');
+        });
+    }
+
+    document.getElementById('acceptCookies').addEventListener('click', function () {
+        sendChoice('/cookie-consent/accept');
+    });
+
+    document.getElementById('declineCookies').addEventListener('click', function () {
+        sendChoice('/cookie-consent/decline');
+    });
+})();
+</script>

--- a/DeliasWebsite/Views/Partials/_Footer.cshtml
+++ b/DeliasWebsite/Views/Partials/_Footer.cshtml
@@ -99,7 +99,7 @@
                     <span class="heart">
                         <i class="fa-solid fa-heart"></i>
                     </span>
-                    All rights reserved.
+                    All rights reserved. <a href="/cookie-consent">Cookie Policy</a>
                 </p>
 
                 <button class="back-to-top">

--- a/DeliasWebsite/wwwroot/css/styles.css
+++ b/DeliasWebsite/wwwroot/css/styles.css
@@ -2248,6 +2248,74 @@
   margin-bottom: var(--spacing-8);
 }
 
+.cookie-consent {
+  padding: 1.5rem 0;
+}
+
+.cookie-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.cookie-table th,
+.cookie-table td {
+  border: 1px solid #e5e7eb;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.cookie-table th {
+  background-color: #f9fafb;
+}
+
+:root[data-theme=dark] .cookie-table th,
+:root[data-theme=dark] .cookie-table td {
+  border-color: #374151;
+}
+
+:root[data-theme=dark] .cookie-table th {
+  background-color: #1f2937;
+}
+
+.cookie-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: #f9fafb;
+  padding: 1rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  z-index: 100;
+}
+.cookie-banner.hidden {
+  display: none;
+}
+.cookie-banner .cookie-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+.cookie-banner .cookie-actions .btn-primary {
+  background-color: #2563eb;
+  color: #fff;
+}
+.cookie-banner .cookie-actions .btn-secondary {
+  background-color: #f3f4f6;
+  color: #111827;
+}
+
+:root[data-theme=dark] .cookie-banner {
+  background-color: #1f2937;
+}
+:root[data-theme=dark] .cookie-banner .btn-secondary {
+  background-color: #374151;
+  color: #f9fafb;
+}
+
 :root {
   --primary-color: #2563eb;
   --primary-hover: #1d4ed8;
@@ -3224,5 +3292,3 @@ body form .field-validation-error.text-danger {
     display: flex;
   }
 }
-
-/*# sourceMappingURL=styles.css.map */

--- a/FE/styles/components/_cookie-consent.scss
+++ b/FE/styles/components/_cookie-consent.scss
@@ -1,0 +1,74 @@
+@use '../variables' as *;
+
+.cookie-consent {
+  padding: $spacing-6 0;
+}
+
+.cookie-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: $spacing-4;
+}
+
+.cookie-table th,
+.cookie-table td {
+  border: 1px solid $border-color;
+  padding: $spacing-2;
+  text-align: left;
+}
+
+.cookie-table th {
+  background-color: $bg-secondary;
+}
+
+:root[data-theme='dark'] .cookie-table th,
+:root[data-theme='dark'] .cookie-table td {
+  border-color: $dark-border-color;
+}
+
+:root[data-theme='dark'] .cookie-table th {
+  background-color: $dark-bg-secondary;
+}
+
+.cookie-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: $bg-secondary;
+  padding: $spacing-4;
+  box-shadow: $shadow-md;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-4;
+  z-index: 100;
+
+  &.hidden {
+    display: none;
+  }
+
+  .cookie-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: $spacing-2;
+
+    .btn-primary {
+      background-color: $primary-color;
+      color: #fff;
+    }
+
+    .btn-secondary {
+      background-color: $bg-tertiary;
+      color: $text-primary;
+    }
+  }
+}
+
+:root[data-theme='dark'] .cookie-banner {
+  background-color: $dark-bg-secondary;
+
+  .btn-secondary {
+    background-color: $dark-bg-tertiary;
+    color: $dark-text-primary;
+  }
+}

--- a/FE/styles/main.scss
+++ b/FE/styles/main.scss
@@ -13,6 +13,7 @@
 @use './components/search';
 @use './components/pagination';
 @use  './components/article';
+@use './components/cookie-consent';
 
 
 // CSS Custom Properties for theme switching


### PR DESCRIPTION
## Summary
- expose endpoints for accepting or declining cookies and storing consent
- render a reusable cookie banner with client-side logic
- style cookie banner and compile assets

## Testing
- `npm --prefix FE run build`
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package dotnet-sdk-8.0)*

------
https://chatgpt.com/codex/tasks/task_e_688e7fc0c0ac832294c219700ce8d9f4